### PR TITLE
If inferConfig is false we can get a circular reference error on the deb...

### DIFF
--- a/lib/tasks/optimize.js
+++ b/lib/tasks/optimize.js
@@ -37,10 +37,21 @@ Optimize = (function() {
   };
 
   Optimize.prototype._executeOptimize = function(runConfig, callback) {
-    var err,
+    var cache, err, replacer,
       _this = this;
     logger.info("Beginning r.js optimization to result in [[ " + runConfig.out + " ]]");
-    logger.debug("Config for r.js run:\n" + (JSON.stringify(runConfig, null, 2)));
+    cache = [];
+    replacer = function(key, value) {
+      if (typeof value === 'object' && value !== null) {
+        if (cache.indexOf(value !== -1)) {
+          return;
+        }
+        cache.push(value);
+      }
+      return value;
+    };
+    logger.debug("Config for r.js run:\n" + (JSON.stringify(runConfig, replacer, 2)));
+    cache = null;
     try {
       return requirejs.optimize(runConfig, function(buildResponse) {
         var i, reportLine, reportLines, _i, _len;

--- a/src/tasks/optimize.coffee
+++ b/src/tasks/optimize.coffee
@@ -26,7 +26,17 @@ class Optimize
 
   _executeOptimize: (runConfig, callback) =>
     logger.info "Beginning r.js optimization to result in [[ #{runConfig.out} ]]"
-    logger.debug "Config for r.js run:\n#{JSON.stringify(runConfig, null, 2)}"
+
+    cache = []
+    replacer = (key, value) ->
+      if typeof value == 'object' && value != null
+        return if cache.indexOf value != -1
+        cache.push value
+      return value
+    # if inferConfig is false we can get a circular reference error on this debug line
+    logger.debug "Config for r.js run:\n#{JSON.stringify(runConfig, replacer, 2)}"
+    cache = null
+
     try
       requirejs.optimize runConfig, (buildResponse) =>
         reportLines = buildResponse.split("\n")


### PR DESCRIPTION
...ug line. Avoid it.

My mimosa config set inferConfig: false and "mimosa watch --optimize" would throw "TypeError: Converting circular structure to JSON"

Fixed using the suggestion from: http://stackoverflow.com/questions/11616630/json-stringify-avoid-typeerror-converting-circular-structure-to-json
