### PR TITLE
support package and map configuration

### DIFF
--- a/src/tasks/register.coffee
+++ b/src/tasks/register.coffee
@@ -386,7 +386,7 @@ module.exports = class RequireRegister
           continue
 
         unless fs.existsSync fullDepPath
-          alias = @_findAlias(aliasPath, @aliasFiles)
+          fullDepPath = @_findAlias(aliasPath, @aliasFiles)
 
         if alias
           #logger.debug "Found mapped dependency [[ #{alias} ]] at [[ #{fullDepPath} ]]"


### PR DESCRIPTION
When working with the requirejs validator, it seems like it currently ignores the package and map sections : 
http://requirejs.org/docs/api.html#packages
http://requirejs.org/docs/api.html#config-map

I've put together a test repo demonstrating how it works in the browser, yet fails mimosa-require verification :
https://github.com/silver83/mimosa-require-test

I'll try to take a look at how hard it will be for me to create a pr for this. 
