### PR TITLE
as written the logic prevented overriding the r.js optimizer (it was onl...

### DIFF
--- a/src/tasks/builder.coffee
+++ b/src/tasks/builder.coffee
@@ -64,11 +64,13 @@ class Optimizer
       _.clone(config.require.optimize.overrides, true)
     else
       {}
+    unless runConfig.optimize? or runConfig.optimize is null
+      runConfig.optimize = if config.isOptimize and config.isMinify
+        "none"
+      else
+        "uglify2"
 
-    runConfig.optimize = if config.isOptimize and config.isMinify
-      "none"
-    else
-      "uglify2"
+
 
     configFile = if fs.existsSync config.require.commonConfig then config.require.commonConfig else file
     baseUrl = path.join config.watch.compiledDir, config.watch.javascriptDir


### PR DESCRIPTION
...y ever none or uglify2)

now you can override it in your mimosa config:

require:
    optimize:
      overrides:
        optimize: "none"
